### PR TITLE
Invert the sensor velocity if the motor is set to be inverted

### DIFF
--- a/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500DriveControllerFactoryBuilder.java
+++ b/src/main/java/com/swervedrivespecialties/swervelib/ctre/Falcon500DriveControllerFactoryBuilder.java
@@ -99,9 +99,13 @@ public final class Falcon500DriveControllerFactoryBuilder {
 
         @Override
         public void setReferenceVoltage(double voltage) {
-            final double percentOutput = voltage / nominalVoltage;
+            double percentOutput = voltage / nominalVoltage;
             motor.set(TalonFXControlMode.PercentOutput, percentOutput);
             if (RobotBase.isSimulation()) {
+                if (motor.getInverted()) {
+                    percentOutput *= -1.0;
+                }
+
                 // SelectedSensorVelocity is raw sensor units per 100ms
                 // See https://store.ctr-electronics.com/content/api/java/html/interfacecom_1_1ctre_1_1phoenix_1_1motorcontrol_1_1_i_motor_controller.html#a2e40db44cfbd62192ffac3fb7ccf5166
                 // Raw sensor units are 2048 ticks per rotation


### PR DESCRIPTION
The MK4 modules have their motors set as inverted, meaning that they move in the opposite direction as the applied voltage
This change updates the simulation code to properly handle that